### PR TITLE
Fix close handler in allMiniTickers

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -426,7 +426,8 @@ const allMiniTickers = (cb, transform = true, variator) => {
     )
   }
 
-  return options => w => w.close(1000, 'Close handle was called', { keepClosed: true, ...options })
+  return options =>
+    w.close(1000, 'Close handle was called', { keepClosed: true, ...options })
 }
 
 const customSubStream = (payload, cb, variator) => {


### PR DESCRIPTION
## Summary
- fix closing callback for `allMiniTickers` websocket helper

## Testing
- `yarn test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840531e19e8832fb988c40693de03c3